### PR TITLE
statusBarTranslucent on Android

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,6 +158,7 @@ export default class Spinner extends React.PureComponent {
         supportedOrientations={['landscape', 'portrait']}
         transparent
         visible={this.state.visible}
+        statusBarTranslucent={true}
       >
         {spinner}
       </Modal>


### PR DESCRIPTION
Added `statusBarTranslucent` property to Modal to support overlay on status bar as well on Android.

Fixes https://github.com/joinspontaneous/react-native-loading-spinner-overlay/issues/99